### PR TITLE
improve file name algorithm for user privacy

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"github.com/joho/godotenv"
 )
 
-
 func main() {
 
 	err := godotenv.Load()


### PR DESCRIPTION
Fixed file naming vulnerability that exposed user IDs.
Previously, file names revealed user IDs in the format
```output_<user_id>_<timestamp>.mp4```
 e.g. 
```output_11223344_1724267014864927602.mp4```
This allowed users to see the sender's user ID when downloading the video. The file naming format has been updated to a more secure format,
```@(Bot username)_(8 char random string).mp4```
 e.g. 
```@VidZipBot_vllhXuLJ.mp4```
which no longer exposes user IDs.